### PR TITLE
Correctly return remaining data after parsing RESP array

### DIFF
--- a/src/redis_reply.erl
+++ b/src/redis_reply.erl
@@ -51,9 +51,9 @@ handle_multi(Data) ->
 
 handle_multi(-1, [], {unknown, <<>>}, Data) ->
     {{value, undefined}, {unknown, Data}};
-handle_multi(Count, Values, {unknown, <<>>}, Data)
+handle_multi(Count, Values, CurValue, <<>>)
   when length(Values) == Count ->
-    {{value, {ok, lists:reverse(Values)}}, {unknown, Data}};
+    {{value, {ok, lists:reverse(Values)}}, CurValue};
 handle_multi(Count, Values, CurValue, Data) ->
     case data(Data, CurValue) of
         {{value, Value}, NextValue} ->
@@ -63,7 +63,7 @@ handle_multi(Count, Values, CurValue, Data) ->
     end.
 
 multi_value(undefined) -> undefined;
-multi_value({ok, Value}) -> Value. 
+multi_value({ok, Value}) -> Value.
 
 handle_message(Data) ->
     case split_crlf(Data) of


### PR DESCRIPTION
I found a bug in the `redis_reply:data/1` parser.

If the redis server should return a reply array followed by any data (PONG in the example below), the `redis_reply` parser will incorrectly include PONG in the list of values, then finally return with a pending status.

``` erlang
1> redis_reply:data(<<"*2\r\n$4\r\nmem2\r\n$4\r\nmem1\r\n+PONG\r\n">>, {unknown, <<>>}).
{pending,{multi,2,
                ["PONG",<<"mem1">>,<<"mem2">>],
                {unknown,<<>>}}}
```

This results in `redis_client` (the calling process) ending up with a broken state that never sends back the replies.

Applying this fix should return the correct values:

``` erlang
1> redis_reply:data(<<"*2\r\n$4\r\nmem2\r\n$4\r\nmem1\r\n+PONG\r\n">>, {unknown, <<>>}).
{{value,{ok,[<<"mem2">>,<<"mem1">>]}},
 {unknown,<<"+PONG\r\n">>}}
```
